### PR TITLE
Set git-repository-url and edit-url-template

### DIFF
--- a/docs/en/book.toml
+++ b/docs/en/book.toml
@@ -5,3 +5,7 @@ src = "src"
 
 [rust]
 edition = "2021"
+
+[output.html]
+git-repository-url = "https://github.com/openrr/openrr-tutorial/tree/main/docs/en"
+edit-url-template = "https://github.com/openrr/openrr-tutorial/tree/main/docs/en/{path}"

--- a/docs/ja/book.toml
+++ b/docs/ja/book.toml
@@ -5,3 +5,7 @@ src = "src"
 
 [rust]
 edition = "2021"
+
+[output.html]
+git-repository-url = "https://github.com/openrr/openrr-tutorial/tree/main/docs/ja"
+edit-url-template = "https://github.com/openrr/openrr-tutorial/tree/main/docs/ja/{path}"


### PR DESCRIPTION
This adds "Git repository" and "Suggest an edit" buttons to the book.

Before:
<img width="471" alt="book-before" src="https://user-images.githubusercontent.com/43724913/217218399-17ddcd8b-e6e0-4c19-95a7-4ad0b8871f20.png">

After:
<img width="471" alt="book-after" src="https://user-images.githubusercontent.com/43724913/217218433-c1373d24-4737-47f0-a194-fae87fc83a3d.png">
