### PR TITLE
Fix case of OS name

### DIFF
--- a/docs/en/src/README.md
+++ b/docs/en/src/README.md
@@ -5,12 +5,12 @@
 | OS             | Core | GUI | ROS | ROS2 |
 | -------------- | ---- | --- | --- | ---- |
 | Linux (Ubuntu) | ✔    | ✔   | ✔   | ✔    |
-| MacOS          | ✔    | ✔   | ✔   |      |
+| macOS          | ✔    | ✔   | ✔   |      |
 | Windows        | ✔    | ✔   |     |      |
 
-Ubuntu is supported as Linux. The approximate functionality is available even under MacOS and Windows.
+Ubuntu is supported as Linux. The approximate functionality is available even under macOS and Windows.
 
-It can be used without ROS installation even when using Linux or MacOS.
+It can be used without ROS installation even when using Linux or macOS.
 
 ## Installation for Rust
 

--- a/docs/en/src/getting_started/apps/installation.md
+++ b/docs/en/src/getting_started/apps/installation.md
@@ -21,7 +21,7 @@ git clone https://github.com/openrr/openrr
 cd openrr
 ```
 
-For Linux and MacOS users.
+For Linux and macOS users.
 
 ```bash
 cargo install --path openrr-apps

--- a/docs/ja/src/README.md
+++ b/docs/ja/src/README.md
@@ -5,12 +5,12 @@
 | OS             | Core | GUI | ROS | ROS2 |
 | -------------- | ---- | --- | --- | ---- |
 | Linux (Ubuntu) | ✔    | ✔   | ✔   | ✔    |
-| MacOS          | ✔    | ✔   | ✔   |      |
+| macOS          | ✔    | ✔   | ✔   |      |
 | Windows        | ✔    | ✔   |     |      |
 
-LinuxとしてUbuntuがサポートされています。MacOSやWindowsであってもおおよその機能は利用できます。
+LinuxとしてUbuntuがサポートされています。macOSやWindowsであってもおおよその機能は利用できます。
 
-LinuxやMacOSを使用している場合でも、ROSをインストールせずに使用することができます。
+LinuxやmacOSを使用している場合でも、ROSをインストールせずに使用することができます。
 
 ## Installation for Rust
 

--- a/docs/ja/src/getting_started/apps/installation.md
+++ b/docs/ja/src/getting_started/apps/installation.md
@@ -21,7 +21,7 @@ git clone https://github.com/openrr/openrr
 cd openrr
 ```
 
-LinuxやMacOSユーザーの方はこちら。
+LinuxやmacOSユーザーの方はこちら。
 
 ```bash
 cargo install --path openrr-apps


### PR DESCRIPTION
Apple's OS names are lower camelCase https://developer.apple.com/macos/